### PR TITLE
Add kext policy support

### DIFF
--- a/sp/SPKernelExtensionPolicy.h
+++ b/sp/SPKernelExtensionPolicy.h
@@ -1,0 +1,13 @@
+#ifndef SPKernelExtensionPolicy_h
+#define SPKernelExtensionPolicy_h
+
+@class SPKernelExtensionPolicyItem;
+
+@interface SPKernelExtensionPolicy : NSObject
+
+- (instancetype)init;
+- (NSArray<SPKernelExtensionPolicyItem *> *)currentPolicy;
+
+@end
+
+#endif /* SPKernelExtensionPolicy_h */

--- a/sp/SPKernelExtensionPolicyItem.h
+++ b/sp/SPKernelExtensionPolicyItem.h
@@ -1,0 +1,17 @@
+#ifndef SPKernelExtensionPolicyItem_h
+#define SPKernelExtensionPolicyItem_h
+
+@interface SPKernelExtensionPolicyItem : NSObject <NSCoding>
+
+@property (readonly, nonatomic) NSString *developerName;
+@property (readonly, nonatomic) NSString *applicationName;
+@property (readonly, nonatomic) NSString *applicationPath;
+@property (readonly, nonatomic) NSString *teamID;
+@property (readonly, nonatomic) NSArray *bundleIDs;
+@property (nonatomic, getter=isAllowed) char allowed;
+@property (readonly, nonatomic, getter=isRebootRequired) char rebootRequired;
+@property (readonly, nonatomic, getter=isModified) char modified;
+
+@end
+
+#endif /* SPKernelExtensionPolicyItem_h */

--- a/sp/SystemPolicyWrapper.h
+++ b/sp/SystemPolicyWrapper.h
@@ -5,6 +5,7 @@
 
 typedef struct {
 	void *framework_handle;
+	NSAutoreleasePool *pool;
 	NSArray<SPExecutionHistoryItem *> *historyItems;
 } history_items;
 
@@ -26,6 +27,7 @@ history_item get_history_item(history_items self, unsigned long index);
 
 typedef struct {
 	void *framework_handle;
+	NSAutoreleasePool *pool;
 	NSArray<SPKernelExtensionPolicyItem *> *kextItems;
 } kext_items;
 

--- a/sp/SystemPolicyWrapper.h
+++ b/sp/SystemPolicyWrapper.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @class SPExecutionHistoryItem;
+@class SPKernelExtensionPolicyItem;
 
 typedef struct {
 	void *framework_handle;
@@ -22,3 +23,25 @@ history_items init_history_items(void);
 void release_history_items(history_items self);
 unsigned long history_items_length(history_items self);
 history_item get_history_item(history_items self, unsigned long index);
+
+typedef struct {
+	void *framework_handle;
+	NSArray<SPKernelExtensionPolicyItem *> *kextItems;
+} kext_items;
+
+typedef struct {
+	const char *developer_name;
+	const char *application_name;
+	const char *application_path;
+	const char *team_id;
+	unsigned long bundle_id_count;
+	char allowed;
+	char reboot_required;
+	char modified;
+} kext_item;
+
+kext_items init_kext_items(void);
+void release_kext_items(kext_items self);
+unsigned long kext_items_length(kext_items self);
+kext_item get_kext_item(kext_items self, unsigned long index);
+const char *get_kext_bundle_id(kext_items self, unsigned long kextIndex, unsigned long bundleIDIndex);

--- a/sp/SystemPolicyWrapper.m
+++ b/sp/SystemPolicyWrapper.m
@@ -2,6 +2,8 @@
 #import "SystemPolicyWrapper.h"
 #import "SPExecutionPolicy.h"
 #import "SPExecutionHistoryItem.h"
+#import "SPKernelExtensionPolicy.h"
+#import "SPKernelExtensionPolicyItem.h"
 
 history_items
 init_history_items(void) {
@@ -31,14 +33,73 @@ history_items_length(history_items self) {
 history_item
 get_history_item(history_items self, unsigned long index) {
 	history_item item;
-	item.exec_path = [self.historyItems[index].execPath UTF8String];
-	item.mmap_path = [self.historyItems[index].mmapPath UTF8String];
-	item.signing_id = [self.historyItems[index].signingID UTF8String];
-	item.team_id = [self.historyItems[index].teamID UTF8String];
-	item.cd_hash = [self.historyItems[index].cdHash UTF8String];
-	item.responsible_path = [self.historyItems[index].responsiblePath UTF8String];
-	item.developer_name = [self.historyItems[index].developerName UTF8String];
-	item.last_seen = [self.historyItems[index].lastSeen timeIntervalSince1970];
+
+	if (index < self.historyItems.count) {
+		item.exec_path = [self.historyItems[index].execPath UTF8String];
+		item.mmap_path = [self.historyItems[index].mmapPath UTF8String];
+		item.signing_id = [self.historyItems[index].signingID UTF8String];
+		item.team_id = [self.historyItems[index].teamID UTF8String];
+		item.cd_hash = [self.historyItems[index].cdHash UTF8String];
+		item.responsible_path = [self.historyItems[index].responsiblePath UTF8String];
+		item.developer_name = [self.historyItems[index].developerName UTF8String];
+		item.last_seen = [self.historyItems[index].lastSeen timeIntervalSince1970];
+	}
 
 	return item;
+}
+
+kext_items
+init_kext_items(void) {
+	kext_items self;
+	self.framework_handle = dlopen("/System/Library/PrivateFrameworks/SystemPolicy.framework/SystemPolicy", RTLD_LAZY);
+
+	if (self.framework_handle != NULL) {
+		Class SPKernelExtensionPolicyClass = NSClassFromString(@"SPKernelExtensionPolicy");
+		SPKernelExtensionPolicy *kextPolicy = [[SPKernelExtensionPolicyClass alloc] init];
+		self.kextItems = [kextPolicy currentPolicy];
+	}
+
+	return self;
+}
+
+void
+release_kext_items(kext_items self) {	
+	self.kextItems = nil;
+	dlclose(self.framework_handle);
+}
+
+unsigned long
+kext_items_length(kext_items self) {
+	return self.kextItems.count;
+}
+
+kext_item
+get_kext_item(kext_items self, unsigned long index) {
+	kext_item item;
+
+	if (index < self.kextItems.count) {
+		item.developer_name = [self.kextItems[index].developerName UTF8String];
+		item.application_name = [self.kextItems[index].applicationName UTF8String];
+		item.application_path = [self.kextItems[index].applicationPath UTF8String];
+		item.team_id = [self.kextItems[index].teamID UTF8String];
+		item.bundle_id_count = self.kextItems[index].bundleIDs.count;
+		item.allowed = [self.kextItems[index] isAllowed];
+		item.reboot_required = [self.kextItems[index] isRebootRequired];
+		item.modified = [self.kextItems[index] isModified];
+	}
+
+	return item;
+}
+
+const char *
+get_kext_bundle_id(kext_items self, unsigned long kextIndex, unsigned long bundleIDIndex) {
+	const char *bundle_id = NULL;
+
+	if (kextIndex < self.kextItems.count) {
+		SPKernelExtensionPolicyItem *item = self.kextItems[kextIndex];
+		if (bundleIDIndex < item.bundleIDs.count) {
+			bundle_id = [item.bundleIDs[bundleIDIndex] UTF8String];
+		}
+	}
+	return bundle_id;
 }

--- a/sp/SystemPolicyWrapper.m
+++ b/sp/SystemPolicyWrapper.m
@@ -11,8 +11,9 @@ init_history_items(void) {
 	self.framework_handle = dlopen("/System/Library/PrivateFrameworks/SystemPolicy.framework/SystemPolicy", RTLD_LAZY);
 
 	if (self.framework_handle != NULL) {
+		self.pool = [[NSAutoreleasePool alloc] init];
 		Class SPExecutionPolicyClass = NSClassFromString(@"SPExecutionPolicy");
-		SPExecutionPolicy *execPolicy = [[SPExecutionPolicyClass alloc] init];
+		SPExecutionPolicy *execPolicy = [[[SPExecutionPolicyClass alloc] init] autorelease];
 		self.historyItems = [execPolicy legacyExecutionHistory];
 	}
 
@@ -22,7 +23,12 @@ init_history_items(void) {
 void
 release_history_items(history_items self) {
 	self.historyItems = nil;
+	
+	[self.pool release];
+	self.pool = nil;
+
 	dlclose(self.framework_handle);
+	self.framework_handle = NULL;
 }
 
 unsigned long
@@ -54,8 +60,9 @@ init_kext_items(void) {
 	self.framework_handle = dlopen("/System/Library/PrivateFrameworks/SystemPolicy.framework/SystemPolicy", RTLD_LAZY);
 
 	if (self.framework_handle != NULL) {
+		self.pool = [[NSAutoreleasePool alloc] init];
 		Class SPKernelExtensionPolicyClass = NSClassFromString(@"SPKernelExtensionPolicy");
-		SPKernelExtensionPolicy *kextPolicy = [[SPKernelExtensionPolicyClass alloc] init];
+		SPKernelExtensionPolicy *kextPolicy = [[[SPKernelExtensionPolicyClass alloc] init] autorelease];
 		self.kextItems = [kextPolicy currentPolicy];
 	}
 
@@ -65,7 +72,12 @@ init_kext_items(void) {
 void
 release_kext_items(kext_items self) {	
 	self.kextItems = nil;
-	dlclose(self.framework_handle);
+
+	[self.pool release];
+	self.pool = nil;
+	
+	dlclose(self.framework_handle);	
+	self.framework_handle = NULL;
 }
 
 unsigned long

--- a/sp/system_policy.go
+++ b/sp/system_policy.go
@@ -1,3 +1,4 @@
+// Package sp provides access to the SystemPolicy.framework on macOS.
 package sp
 
 /*
@@ -11,6 +12,7 @@ import (
 	"time"
 )
 
+// An ExecutionHistoryItem represents a 32-bit application that has been run.
 type ExecutionHistoryItem struct {
 	ExecPath        string
 	MmapPath        string
@@ -22,6 +24,21 @@ type ExecutionHistoryItem struct {
 	LastSeen        time.Time
 }
 
+// A KernelExtensionPolicyItem represents a KEXT that is either waiting for
+// approval to load or is was approved and loaded.
+type KernelExtensionPolicyItem struct {
+	DeveloperName   string
+	ApplicationName string
+	ApplicationPath string
+	TeamID          string
+	BundleID        string
+	Allowed         bool
+	RebootRequired  bool
+	Modified        bool
+}
+
+// LegacyExecutionHistory returns a list of 32-bit applications that have
+// been executed on a macOS machine.
 func LegacyExecutionHistory() []ExecutionHistoryItem {
 	self := C.init_history_items()
 	defer C.release_history_items(self)
@@ -47,4 +64,34 @@ func LegacyExecutionHistory() []ExecutionHistoryItem {
 	}
 
 	return history
+}
+
+// CurrentKernelExtensionPolicy returns a list of items that represent whether
+// a specific KEXT was approved and loaded or not.
+func CurrentKernelExtensionPolicy() []KernelExtensionPolicyItem {
+	self := C.init_kext_items()
+	defer C.release_kext_items(self)
+
+	policy := make([]KernelExtensionPolicyItem, 0)
+
+	length := uint64(C.kext_items_length(self))
+	for i := uint64(0); i < length; i++ {
+		item := C.get_kext_item(self, C.ulong(i))
+
+		for j := uint64(0); j < uint64(item.bundle_id_count); j++ {
+			ki := KernelExtensionPolicyItem{}
+			ki.DeveloperName = C.GoString(item.developer_name)
+			ki.ApplicationName = C.GoString(item.application_name)
+			ki.ApplicationPath = C.GoString(item.application_path)
+			ki.TeamID = C.GoString(item.team_id)
+			ki.BundleID = C.GoString(C.get_kext_bundle_id(self, C.ulong(i), C.ulong(j)))
+			ki.Allowed = item.allowed == '\x01'
+			ki.RebootRequired = item.reboot_required == '\x01'
+			ki.Modified = item.modified == '\x01'
+
+			policy = append(policy, ki)
+		}
+	}
+
+	return policy
 }


### PR DESCRIPTION
This adds support for the kext authorization policy information from the SystemPolicy.framework. There is a new `kext_policy` table that provides information about what kexts have been authorized or are waiting to be authorized.

* [x] Need to update README with documentation on new table